### PR TITLE
「プレースホルダと変数のMapが変更不可な場合のテストに変更」のテスト改善

### DIFF
--- a/src/test/java/nablarch/integration/mail/freemarker/FreeMarkerMailProcessorContainerManagedTest.java
+++ b/src/test/java/nablarch/integration/mail/freemarker/FreeMarkerMailProcessorContainerManagedTest.java
@@ -44,7 +44,7 @@ public class FreeMarkerMailProcessorContainerManagedTest {
                 Collections.unmodifiableMap(variables));
 
         assertThat(result.getSubject(), is("あああ0"));
-        assertThat(result.getMailBody(), is("いいい\r\nえええ1\r\nえええ2\r\nえええ3\r\n"));
+        assertThat(result.getMailBody(), is("いいい\nえええ1\nえええ2\nえええ3\n"));
     }
 
     public static class ConfigurationFactory implements ComponentFactory<Configuration> {


### PR DESCRIPTION
「 #2 プレースホルダと変数のMapが変更不可な場合のテストに変更」実施の際、テンプレートファイルに\rが含まれていないのに期待値に「\r」が含まれていた問題に対応。